### PR TITLE
Use getWeekInfo() instead of weekInfo

### DIFF
--- a/src/intl.js
+++ b/src/intl.js
@@ -66,7 +66,7 @@ function normalizeCompact(locale, style) {
 function getFirstDayOfWeek(locale) {
   try {
     // @ts-ignore
-    return new Intl.Locale(locale).weekInfo.firstDay;
+    return new Intl.Locale(locale).getWeekInfo().firstDay;
   } catch {
     return 0;
   }


### PR DESCRIPTION
weekInfo is changed to getWeekInfo() in https://tc39.es/proposal-intl-locale-info/

See tc39/proposal-intl-locale-info#67